### PR TITLE
Bug: Due to possible incompatibility

### DIFF
--- a/gol/src/main/java/de/hawhamburg/inf/gol/Application.java
+++ b/gol/src/main/java/de/hawhamburg/inf/gol/Application.java
@@ -70,6 +70,7 @@ public class Application {
             // window repaint to update the graphics
             pool.submit(() -> {
                 playground.asList().forEach(cell -> cell.nextGen());
+                window.validate();
                 window.repaint();
             });
             


### PR DESCRIPTION
Aufgrund einer möglichen Inkompatibilität zwischen Java Swing und Apple Arm Prozessoren ist der aufruf von window.validate() nötig um beim starten der Applikation sicherzustellen, dass diese auch korrekt angezeigt wird. 